### PR TITLE
Blackduck: Automated PR: Update com.thoughtworks.xstream:xstream:1.4.5 to 1.4.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <webwolf.port>9090</webwolf.port>
     <wiremock.version>3.13.0</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.21</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.9.0</zxcvbn.version>
   </properties>


### PR DESCRIPTION
## Vulnerabilities associated with com.thoughtworks.xstream:xstream:1.4.5
[BDSA-2013-0046](https://openhub.net/vulnerabilities/bdsa/BDSA-2013-0046) *(CRITICAL)*: Xstream is vulnerable to remote code execution (RCE) by an attacker who can supply a specially crafted input stream.

[BDSA-2021-2603](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2603) *(CRITICAL)*: XStream is vulnerable to remote code execution (RCE) due to the unsafe deserialization of classes. A remote attacker could execute arbitrary code on a vulnerable server by causing that server to deserialize a maliciously crafted serialized object.

[BDSA-2020-3372](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-3372) *(CRITICAL)*: Xstream is vulnerable to remote code execution (RCE) through specially crafted input. A remote attacker is able to execute arbitrary system commands on the host machine if Xstream's security framework has been configured with a default blacklist, rather than the more secure whitelisting method.

[BDSA-2021-2602](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2602) *(CRITICAL)*: XStream is vulnerable to remote code execution (RCE) due to the unsafe deserialization of classes. A remote attacker could execute arbitrary code on a vulnerable server by causing that server to deserialize a maliciously crafted serialized object.

[BDSA-2021-2593](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2593) *(CRITICAL)*: XStream is vulnerable to remote code execution (RCE) due to the unsafe deserialization of classes. A remote attacker could execute arbitrary code on a vulnerable server by causing that server to deserialize a maliciously crafted serialized object.

[BDSA-2021-2590](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2590) *(CRITICAL)*: XStream is vulnerable to remote code execution (RCE) due to the unsafe deserialization of classes. A remote attacker could execute arbitrary code on a vulnerable server by causing that server to deserialize a maliciously crafted serialized object.

[BDSA-2021-2581](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2581) *(CRITICAL)*: XStream is vulnerable to unsafe deserialization of user-controlled input. A remote attacker could leverage this to execute arbitrary code from a remote server.

**Note:** If the application uses XStream's security framework and whitelist approach to deserialization (recommended), it is not vulnerable.

[BDSA-2021-2580](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2580) *(CRITICAL)*: XStream is vulnerable to unsafe deserialization of attacker controlled input. A remote attacker could leverage this to execute arbitrary code from a remote server.

**Note** If the application uses XStreams security framework and whitelist approach to deserialization (recommended), it is not vulnerable.

[BDSA-2021-2573](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2573) *(CRITICAL)*: XStream is vulnerable to unsafe deserialization of attacker controlled input. A remote attacker could leverage this to execute arbitrary code from a remote server.

Note that if the application uses XStreams security framework and whitelist approach to deserialization (recommended), it is not vulnerable.

[BDSA-2021-2569](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2569) *(CRITICAL)*: XStream is vulnerable to unsafe deserialization of attacker controlled input. A remote attacker could leverage this to execute arbitrary system commands.

Note that if the application uses XStream's security framework and allowlist approach to deserialization (recommended), it is not vulnerable.

This vulnerability is listed as exploitable by the Cybersecurity & Infrastructure Security Agency in their [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).

[BDSA-2021-2565](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2565) *(HIGH)*: XStream is vulnerable to remote code execution (RCE) due to the unsafe demarshalling of CORBA and XSLTC classes. A remote attacker could execute arbitrary code on a vulnerable server by causing that server to deserialize a maliciously crafted serialized object.

[BDSA-2021-0724](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0724) *(HIGH)*: Xstream is vulnerable to remote code execution (RCE) by an attacker who can supply a specially crafted input stream.

[BDSA-2021-0736](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0736) *(HIGH)*: XStream, when in its default configuration or operating without a sufficient blacklist / whitelist configuration, is vulnerable to a server-side request forgery (SSRF) issue. This is due to how XStream can potentially create new instances of dangerous objects that are not blocked based on the contents of the input stream. The potentially dangerous types in this case are `sun.awt.datatransfer.DataTransferer$IndexOrderComparator` and `javax.activation.URLDataSource`.

An attacker could supply a crafted input to XStream in order request information from internal resources.

[BDSA-2021-1626](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-1626) *(HIGH)*: XStream, when in its default configuration or operating without a sufficient blacklist / whitelist configuration, is vulnerable to an arbitrary code execution issue. This is due to how XStream can potentially create new instances of dangerous objects that are not blocked based on the contents of the input stream. The potentially dangerous type in this case is `sun.jndi.toolkit.dir.LazySearchEnumerationImpl`.

An attacker could supply a crafted input to XStream in order execute arbitrary code stored on a remote host.

[BDSA-2021-0730](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0730) *(HIGH)*: XStream, when in its default configuration or operating without a sufficient blacklist / whitelist configuration, is vulnerable to an arbitrary code execution issue. This is due to how XStream can potentially create new instances of dangerous objects that are not blocked based on the contents of the input stream. The potentially dangerous types in this case are the JAXB `Accessor$GetterSetterReflection` internal type and `com.sun.rowset.JdbcRowSetImpl`.

An attacker could supply a crafted input to XStream in order execute arbitrary code stored on a remote host.

[BDSA-2021-2568](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2568) *(HIGH)*: XStream is vulnerable to remote code execution (RCE) due to the unsafe demarshalling of the `KeyStoreResolver$KeyStoreIterator` subclass. A remote attacker could execute arbitrary code on a vulnerable server by causing that server to deserialize a maliciously crafted serialized object.

[BDSA-2021-0728](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0728) *(HIGH)*: XStream, when in its default configuration or operating without a sufficient blacklist / whitelist configuration, is vulnerable to an arbitrary command execution issue. This is due to how XStream can potentially create new instances of dangerous objects that are not blocked based on the contents of the input stream. The potentially dangerous type in this case is `com.sun.corba.se.impl.activation.ServerTableEntry`.

An attacker could supply a crafted input to XStream in order execute arbitrary commands on the XStream host.

[BDSA-2021-0726](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0726) *(HIGH)*: XStream, when in its default configuration or operating without a sufficient blacklist / whitelist configuration, is vulnerable to an arbitrary code execution issue. This is due to how XStream can potentially create new instances of dangerous objects that are not blocked based on the contents of the input stream. The potentially dangerous type in this case is `sun.swing.SwingLazyValue`.

An attacker could supply a crafted input to XStream in order execute arbitrary code stored on a remote host.

[BDSA-2021-2576](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2576) *(HIGH)*: XStream is vulnerable to remote code execution (RCE) due to the unsafe deserialization of classes from the `com.sun.java.util.jar.pack` package. A remote attacker could execute arbitrary code on a vulnerable server by causing it to process a maliciously crafted serialized object.

[BDSA-2021-0731](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0731) *(HIGH)*: XStream is vulnerable to server-side request forgery (SSRF) by a remote attacker who can supply a specially crafted input stream to modify or inject objects. This allows them to request data from the internal network that the XStream application is hosted on.

[BDSA-2021-0722](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0722) *(HIGH)*: XStream, when in its default configuration or operating without a sufficient blacklist / whitelist configuration, is vulnerable to an arbitrary code execution issue. This is due to how XStream can potentially create new instances of dangerous objects that are not blocked based on the contents of the input stream. The potentially dangerous type in this case are `javafx.collections.ObservableList` and `JavacProcessingEnvironment$NameProcessIterator`.

An attacker could supply a crafted input to XStream in order execute arbitrary code stored on a remote host.

[BDSA-2021-2586](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2586) *(HIGH)*: XStream is vulnerable to server-side request forgery (SSRF) due to the improper restriction of deserialization functionality. A remote attacker could send requests to intranet hosts by sending maliciously crafted serialized data to a vulnerable server.

 **Note** If the application uses XStreams security framework and whitelist approach to deserialization (recommended), it is not vulnerable.

[BDSA-2021-2587](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2587) *(HIGH)*: XStream is vulnerable to server-side request forgery (SSRF) due to the improper restriction of deserialization functionality. A remote attacker could send requests to intranet hosts by sending maliciously crafted serialized data to a vulnerable server.

 **Note** If the application uses XStreams security framework and whitelist approach to deserialization (recommended), it is not vulnerable.

[BDSA-2021-0721](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0721) *(HIGH)*: Xstream is vulnerable to remote code execution (RCE) by an attacker who can supply a specially crafted input stream.

[BDSA-2020-3787](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-3787) *(HIGH)*: Xstream is vulnerable to an information disclosure flaw where it can be tricked into including remote resources when unmarshalling specially crafted input. A remote attacker could learn details about the internal network.

[BDSA-2020-3780](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-3780) *(HIGH)*: XStream is vulnerable to an arbitrary file deletion flaw in it's handling of unmarshalling specially crafted input. A remote attacker could delete arbitrary files on the server, if the server process has sufficient rights. As well as impacting the integrity of data, this might lead to a denial-of-service (DoS) of applications on the system that rely on specific files for their operation.

[BDSA-2016-0027](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-0027) *(HIGH)*: XStream, when using some supported parsers, is vulnerable to an XML entity expansion issue due to how these parsers can process external entities by default.

A remote attacker could use this issue to retrieve the content of arbitrary files with known locations in a local file system if the Java process has read access.

**Note**: XStream is not vulnerable if the default XML Pull Parser (`Xpp3` or `kXML2`) is used. These parser types do not process XML entities.

[BDSA-2024-8322](https://openhub.net/vulnerabilities/bdsa/BDSA-2024-8322) *(HIGH)*: XStream is vulnerable to a stack overflow issue when configured to use the `BinaryStreamDriver`. A remote attacker who can manipulate a binary input stream could cause a denial-of-service (DoS).

[Click Here To See More Details On Server](https://sca.field-test.blackduck.com/api/projects/d3f49a5b-ee73-47db-8c14-0ddc021eb853/versions/57c2e413-7cff-4979-941b-dc96af93b5df/vulnerability-bom?selectedItem=a15c9ae0-8262-43f3-a281-3fa59003b486)